### PR TITLE
fix: correct Unkown to Unknown typo in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -175,7 +175,7 @@ def resize_3d_short(dmap: np.ndarray, factor: float, dmap_type: str = "depth"):
     elif dmap_type == "disparity":
         _fast_warp_disparity(hdmap, pts)
     else:
-        raise Exception(f"Unkown type {dmap_type}. Need depth or disparity")
+        raise Exception(f"Unknown type {dmap_type}. Need depth or disparity")
 
     scale_factor = 1 if dmap_type == "depth" else factor
 


### PR DESCRIPTION
Fix typo: `Unkown` → `Unknown` in utils.py exception message (line 178).

The exception message now correctly spells 'Unknown' when an unknown depth map type is encountered.

Signed-off-by: Jah-yee <166608075+Jah-yee@users.noreply.github.com>